### PR TITLE
Add mark season watched endpoint

### DIFF
--- a/src/controllers/__tests__/userStreamingHistoryController.spec.ts
+++ b/src/controllers/__tests__/userStreamingHistoryController.spec.ts
@@ -280,6 +280,33 @@ describe('UserStreamingHistoryController', () => {
     });
   });
 
+  describe('markSeasonAsWatched', () => {
+    it('should mark season as watched', async () => {
+      const userId = validId;
+      const contentId = validId;
+      const seasonNumber = 1;
+      mockReq.body = { userId, contentId, seasonNumber };
+
+      const watchHistoryEntry: WatchHistoryEntry = {
+        contentId: contentId,
+        contentType: 'series',
+        title: 'Test Series',
+        watchedDurationInMinutes: 0,
+        completionPercentage: 0,
+        seriesProgress: new Map(),
+        watchedAt: new Date(),
+      };
+
+      mockService.markSeasonAsWatched.mockResolvedValue(watchHistoryEntry);
+
+      await controller.markSeasonAsWatched(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockService.markSeasonAsWatched).toHaveBeenCalledWith(userId, contentId, seasonNumber);
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith({ message: 'Season marked as watched', history: watchHistoryEntry });
+    });
+  });
+
   describe('getEpisodesWatched', () => {
     it('should get episodes watched', async () => {
       const userId = validId;

--- a/src/controllers/userStreamingHistoryController.ts
+++ b/src/controllers/userStreamingHistoryController.ts
@@ -131,7 +131,23 @@ export class UserStreamingHistoryController {
 
     const history = await this.service.addEpisodeToHistory(userId, contentId, episodeData);
     res.status(201).json({ message: 'Episode added to history successfully', history });
-  }); 
+  });
+
+  markSeasonAsWatched = catchAsync(async (req: Request, res: Response) => {
+    const { userId, contentId, seasonNumber } = req.body;
+
+    logger.info({
+      message: 'Mark season as watched',
+      userId,
+      contentId,
+      seasonNumber,
+      method: req.method,
+      path: req.path,
+    });
+
+    const history = await this.service.markSeasonAsWatched(userId, contentId, seasonNumber);
+    res.status(200).json({ message: 'Season marked as watched', history });
+  });
   
   getEpisodesWatched = catchAsync(async (req: Request, res: Response) => {
     const { userId, contentId } = req.query as { userId: string; contentId: string; };

--- a/src/interfaces/services.ts
+++ b/src/interfaces/services.ts
@@ -22,6 +22,7 @@ export interface IUserStreamingHistoryService {
   removeEpisodeFromHistory(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, episodeId: string | Types.ObjectId): Promise<WatchHistoryEntry | null>;
   getTotalWatchTime(userId: string | Types.ObjectId): Promise<number>;
   addEpisodeToHistory(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, episodeData: EpisodeWatched): Promise<WatchHistoryEntry | null>;
+  markSeasonAsWatched(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, seasonNumber: number): Promise<WatchHistoryEntry | null>;
   getEpisodesWatched(userId: string | Types.ObjectId, contentId: string | Types.ObjectId): Promise<Map<string, EpisodeWatched> | null>;
 }
 

--- a/src/routes/__test__/userStreamingHistoryRoutes.spec.ts
+++ b/src/routes/__test__/userStreamingHistoryRoutes.spec.ts
@@ -13,7 +13,8 @@ const mockImplementations = {
   getByUserIdAndStreamingId: jest.fn(),
   addEpisodeToHistory: jest.fn(),
   removeEpisodeFromHistory: jest.fn(),
-  getEpisodesWatched: jest.fn()
+  getEpisodesWatched: jest.fn(),
+  markSeasonAsWatched: jest.fn()
 };
 
 jest.mock('../../controllers/userStreamingHistoryController', () => ({
@@ -277,6 +278,27 @@ describe('User Streaming History Routes', () => {
 
       expect(response.body).toHaveProperty('message', 'Episode added to history successfully');
       expect(response.body).toHaveProperty('episode');
+    });
+  });
+
+  describe('POST /mark-season-watched', () => {
+    it('should mark season as watched', async () => {
+      const payload = {
+        userId: mockUserId.toString(),
+        contentId: mockContentId.toString(),
+        seasonNumber: 1,
+      };
+
+      mockImplementations.markSeasonAsWatched = jest.fn((req: Request, res: Response) => {
+        res.status(HttpStatus.OK).json({ message: 'Season marked as watched' });
+      });
+
+      const response = await request(app)
+        .post('/streaming-history/mark-season-watched')
+        .send(payload)
+        .expect(HttpStatus.OK);
+
+      expect(response.body).toEqual({ message: 'Season marked as watched' });
     });
   });
 

--- a/src/routes/userStreamingHistoryRoutes.ts
+++ b/src/routes/userStreamingHistoryRoutes.ts
@@ -8,11 +8,12 @@ import { validateObjectId } from '../middleware/objectIdValidationMiddleware';
 import { validate } from '../middleware/validationMiddleware';
 import { paginationSchema } from '../validators';
 import { 
-  userStreamingHistoryAddEntrySchema, 
+  userStreamingHistoryAddEntrySchema,
   userStreamingHistoryRemoveEntrySchema,
   userStreamingHistoryGetByUserIdAndStreamingIdSchema,
   userStreamingHistoryAddEpisodeSchema,
-  userStreamingHistoryRemoveEpisodeSchema, 
+  userStreamingHistoryRemoveEpisodeSchema,
+  userStreamingHistoryMarkSeasonSchema,
 } from '../validators/userStreamingHistorySchema';
 
 const router: Router = Router();
@@ -244,6 +245,37 @@ router.post(
   '/add-episode',
   validate(userStreamingHistoryAddEpisodeSchema),
   controller.addEpisodeToHistory,
+);
+
+/**
+ * @swagger
+ * /streaming-history/mark-season-watched:
+ *   post:
+ *     summary: Mark all episodes from a season as watched
+ *     tags: [Streaming History]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - userId
+ *               - contentId
+ *               - seasonNumber
+ *     responses:
+ *       200:
+ *         description: Season marked as watched
+ *       400:
+ *         description: Invalid request data
+ *       500:
+ *         description: Server error
+ */
+
+router.post(
+  '/mark-season-watched',
+  validate(userStreamingHistoryMarkSeasonSchema),
+  controller.markSeasonAsWatched,
 );
 
 /**

--- a/src/services/__test__/userStreamingHistoryService.spec.ts
+++ b/src/services/__test__/userStreamingHistoryService.spec.ts
@@ -298,6 +298,26 @@ describe('UserStreamingHistoryService', () => {
     });
   });
 
+  describe('markSeasonAsWatched', () => {
+    it('should mark season as watched', async () => {
+      const episodes = [{
+        _id: mockEpisodeId.toString(),
+        episodeNumber: 1,
+        durationInMinutes: 45,
+      }];
+      const season = { episodes } as any;
+      jest.spyOn(mockUserStreamingHistoryRepository, 'updateEpisodeProgress').mockResolvedValue(mockWatchHistoryEntry);
+      const seasonRepo = (userStreamingHistoryService as any).seasonRepository;
+      jest.spyOn(seasonRepo, 'findEpisodesBySeasonNumber').mockResolvedValue(season);
+
+      const result = await userStreamingHistoryService.markSeasonAsWatched(mockUserId, mockContentId, 1);
+
+      expect(seasonRepo.findEpisodesBySeasonNumber).toHaveBeenCalledWith(mockContentId, 1);
+      expect(mockUserStreamingHistoryRepository.updateEpisodeProgress).toHaveBeenCalled();
+      expect(result).toEqual(mockWatchHistoryEntry);
+    });
+  });
+
   describe('getEpisodesWatched', () => {
     it('should return episodes watched for a series', async () => {
       const historyWithEpisodes = {

--- a/src/validators/userStreamingHistorySchema.ts
+++ b/src/validators/userStreamingHistorySchema.ts
@@ -75,3 +75,9 @@ export const userStreamingHistoryAddEpisodeSchema = z.object({
   contentId: objectIdSchema,
   episodeData: episodeWatchedSchema,
 });
+
+export const userStreamingHistoryMarkSeasonSchema = userContentIdentifierSchema.extend({
+  seasonNumber: z.number().min(1),
+});
+
+export type UserStreamingHistoryMarkSeasonPayload = z.infer<typeof userStreamingHistoryMarkSeasonSchema>;


### PR DESCRIPTION
## Summary
- add schema for marking an entire season as watched
- expose new `markSeasonAsWatched` method in `IUserStreamingHistoryService`
- implement season mark logic in service
- expose controller and route for POST `/streaming-history/mark-season-watched`
- update tests for new functionality
- fix closing parenthesis for add-episode route
