### PR TITLE
Minor Improvements & Cover Automation – v1.3.1

### DIFF
--- a/.github/workflows/weekly-cover-update.yml
+++ b/.github/workflows/weekly-cover-update.yml
@@ -10,8 +10,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Wake up server via /health
+        run: |
+          for i in {1..5}; do
+            echo "Checking health (attempt $i)..."
+            code=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTH_CHECK_URL")
+            if [ "$code" = "200" ]; then
+              echo "Server is up!"
+              break
+            fi
+            echo "Still sleeping... waiting 15s"
+            sleep 15
+          done
+        env:
+          HEALTH_CHECK_URL: ${{ secrets.HEALTH_CHECK_URL }}
+
       - name: Call /streamingTypes/change-cover
         run: |
+          echo "Calling $COVER_UPDATE_API_URL"
           curl -X GET "$COVER_UPDATE_API_URL" \
             -H "Authorization: $COVER_UPDATE_TOKEN" \
             -H "Content-Type: application/json"

--- a/.github/workflows/weekly-cover-update.yml
+++ b/.github/workflows/weekly-cover-update.yml
@@ -1,0 +1,20 @@
+name: Weekly Cover Update
+
+on:
+  schedule:
+    - cron: '0 12 * * 0'  # Todos os domingos às 12h UTC (09h de Brasília)
+  workflow_dispatch:       # Permite execução manual
+
+jobs:
+  call-cover-update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Call /streamingTypes/change-cover
+        run: |
+          curl -X GET "$COVER_UPDATE_API_URL" \
+            -H "Authorization: $COVER_UPDATE_TOKEN" \
+            -H "Content-Type: application/json"
+        env:
+          COVER_UPDATE_API_URL: ${{ secrets.COVER_UPDATE_API_URL }}
+          COVER_UPDATE_TOKEN: ${{ secrets.COVER_UPDATE_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 4. Create release tag
 5. Deploy to production
 
+## [1.3.1]
+### Added
+- Enhanced test coverage for `seriesController` and `authMiddleware` with new scenarios
+- Added unit tests for `/season` routes with CronJob mocked to prevent open handles
+- New GitHub Action workflow: weekly auto-trigger for cover updates on Sundays
+- Health check step in workflow to handle cold start on Render
+- New `test:debug` script for Jest with open handle and heap tracking
+- Extended response metadata for streaming cover update endpoint
+
+### Changed
+- Cleaned up redundant indexes in `genres`, `streamingTypes`, and `userStreamingHistory` schemas
+- Improved test stability and coverage in `streamingTypeController`
+- Updated response format in `/change-cover` for more consistent API structure
+
+### Fixed
+- Corrected response status and formatting in `changeCover` tests
+
 ## [1.3.0]
 ### Planned
 - User authentication and authorization

--- a/README.MD
+++ b/README.MD
@@ -245,14 +245,34 @@ npm run test
 npm run test:coverage
 ```
 
+## 🧪 Debugging Tests
+
+You can use the following command to help detect open handles or memory leaks during test execution:
+
+```bash
+npm run test:debug
+```
+
 ## 📦 Versioning
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer).
 
-Current version: 1.3.0
+Current version: 1.3.1
 
 For detailed release notes and version history, please see our [CHANGELOG.md](CHANGELOG.md).
 For detailed architecture ideas and notes, please see our [ARCHITECTURE.md](ARCHITECTURE.md).
+
+
+## 🤖 GitHub Workflows
+
+A weekly scheduled GitHub Action was added to automatically trigger cover image updates for streaming types.
+
+- **Schedule:** Every Sunday at 12:00 UTC
+- **Steps:**
+  - Wake up Render server using `/health` endpoint
+  - Trigger `/streamingTypes/change-cover`
+
+You can find the workflow in `.github/workflows/cron.yaml`
 
 ## 🤝 Contributing
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
+    "test:debug": "jest --runInBand --detectOpenHandles --logHeapUsage",
     "prettier:write": "prettier --write \"src/**/*.ts\""
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-streaming-time-api",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/constants/errorMessages.ts
+++ b/src/constants/errorMessages.ts
@@ -35,6 +35,7 @@ export const ErrorMessages = {
   // Series erros
   SERIE_NOT_FOUND: 'Serie not found',
   SERIES_NOT_FOUND: 'Series not found',
+  SERIES_NOT_FOUND_BY_TITLE: 'Series not found with the provided title',
   SERIES_TITLE_REQUIRED: 'Title is required',
   SERIES_NUMBER_OF_EPISODES_REQUIRED: 'Number of episodes is required',
   SERIES_NUMBER_OF_SEASONS_REQUIRED: 'Number of seasons is required',

--- a/src/controllers/__tests__/seriesController.spec.ts
+++ b/src/controllers/__tests__/seriesController.spec.ts
@@ -8,6 +8,7 @@ import { SeriesRepository } from '../../repositories/seriesRepository';
 import { TMDBService } from '../../services/tmdbService';
 import { SeasonRepository } from '../../repositories/seasonRepository';
 import { Messages } from '../../constants/messages';
+import { ErrorMessages } from '../../constants/errorMessages';
 
 jest.mock('../../services/seriesService');
 
@@ -140,6 +141,20 @@ describe('SeriesController', () => {
       expect(mockRes.status).toHaveBeenCalledWith(200);
       expect(mockRes.json).toHaveBeenCalledWith([mockSeries]);
     });
+
+    it('should return a not found message when series not found by title', async () => {
+      const title = 'Test';
+      const limit = 10;
+      const skip = 0;
+      mockReq.query = { title };
+      mockService.getSeriesByTitle.mockResolvedValue([]);
+
+      await controller.getSeriesByTitle(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockService.getSeriesByTitle).toHaveBeenCalledWith(title, skip, limit);
+      expect(mockRes.status).toHaveBeenCalledWith(404);
+      expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({ message: ErrorMessages.SERIES_NOT_FOUND_BY_TITLE }));
+    })
   });
 
   describe('getSeriesByGenre', () => {

--- a/src/controllers/__tests__/streamingTypeController.spec.ts
+++ b/src/controllers/__tests__/streamingTypeController.spec.ts
@@ -266,8 +266,10 @@ describe('StreamingTypeController', () => {
       await controller.changeCover(mockReq as Request, mockRes as Response, mockNext);
 
       expect(mockService.changeCover).toHaveBeenCalled();
-      expect(mockRes.status).toHaveBeenCalledWith(204);
-      expect(mockRes.send).toHaveBeenCalledWith(Messages.COVER_CHANGED_SUCCESSFULLY);
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({
+        message: Messages.COVER_CHANGED_SUCCESSFULLY
+      }));
     });
   });
 

--- a/src/controllers/seriesController.ts
+++ b/src/controllers/seriesController.ts
@@ -7,6 +7,7 @@ import { StreamingServiceError } from '../middleware/errorHandler';
 import axios from 'axios';
 import { Messages } from "../constants/messages";
 import { PaginationSchemaType, SeriesByTitleParamSchemaType } from "../validators";
+import { ErrorMessages } from "../constants/errorMessages";
 
 export class SeriesController {
   skipCheckTitles: boolean = true;
@@ -42,7 +43,7 @@ export class SeriesController {
     if (series && series.length > 0) {
       res.status(200).json(series)
     } else {
-      res.status(404).json({ message: "Series not found with the provided title" });
+      res.status(404).json({ message: ErrorMessages.SERIES_NOT_FOUND_BY_TITLE });
     }
   });
 

--- a/src/controllers/streamingTypeController.ts
+++ b/src/controllers/streamingTypeController.ts
@@ -129,8 +129,12 @@ export class StreamingTypeController {
     });
 
     await this.service.changeCover();
-    res.status(204).send(Messages.COVER_CHANGED_SUCCESSFULLY);
-  });
+    res.status(200).json({
+      message: Messages.COVER_CHANGED_SUCCESSFULLY,
+      updated: true,
+      executedBy: req.user,
+      timestamp: new Date().toISOString()
+    });  });
 
   syncStreamingTypesWithGenres = catchAsync(async (req: Request, res: Response) => {
     logger.info({

--- a/src/models/__tests__/userModel.spec.ts
+++ b/src/models/__tests__/userModel.spec.ts
@@ -227,6 +227,19 @@ describe('User Model', () => {
       expect(isPasswordCorrect).toBe(false);
     });
 
+    it('should reject empty password', async () => {
+      const emptyPassword = '';
+
+      const mockUser = {
+        username: 'testauth',
+        email: 'testauth@example.com',
+        correctPassword: User.prototype.correctPassword
+      } as Partial<typeof User> as any;
+            
+      const isPasswordEmpty = await mockUser.correctPassword(emptyPassword);
+      expect(isPasswordEmpty).toBe(false);
+    });
+
     it('should detect password change after JWT issued', async () => {
       const user = new User({
         username: 'testauth',

--- a/src/models/genresModel.ts
+++ b/src/models/genresModel.ts
@@ -37,10 +37,6 @@ const genreSchema = new Schema<IGenreSchema>(
   }
 );
 
-genreSchema.index({ name: 1 });
-genreSchema.index({ id: 1 });
-
-
 genreSchema.static('findByName', function(name: string): Promise<IGenreResponse | null> {
   return this.findOne({ name: new RegExp(`^${name}$`, 'i') });
 });

--- a/src/models/streamingTypesModel.ts
+++ b/src/models/streamingTypesModel.ts
@@ -48,7 +48,6 @@ const streamingTypesSchema = new Schema<IStreamingTypeDocument, IStreamingTypeMo
   }
 );
 
-streamingTypesSchema.index({ name: 1 }, { unique: true });
 streamingTypesSchema.index({ 'supportedGenres.name': 1 });
 
 streamingTypesSchema.static('findByName', function(name: string): Promise<IStreamingTypeResponse | null> {

--- a/src/models/userStreamingHistoryModel.ts
+++ b/src/models/userStreamingHistoryModel.ts
@@ -459,7 +459,6 @@ userStreamingHistorySchema.static('getWatchedEpisodesForSeries', async function(
 //   // na sequência após o último assistido
 // });
 
-userStreamingHistorySchema.index({ userId: 1 });
 userStreamingHistorySchema.index({ 'watchHistory.contentId': 1 });
 userStreamingHistorySchema.index({ 'watchHistory.watchedAt': -1 });
 userStreamingHistorySchema.index({ 'watchHistory.contentType': 1 });

--- a/src/routes/__test__/seasonRoutes.spec.ts
+++ b/src/routes/__test__/seasonRoutes.spec.ts
@@ -33,6 +33,17 @@ jest.mock('../../middleware/objectIdValidationMiddleware', () => ({
   }),
 }));
 
+jest.mock('cron', () => {
+  return {
+    CronJob: jest.fn().mockImplementation(() => {
+      return {
+        start: jest.fn(),
+        stop: jest.fn(),
+      };
+    }),
+  };
+});
+
 import router from '../seasonRoutes';
 
 describe('Season Routes', () => {

--- a/src/services/__test__/tokenService.spec.ts
+++ b/src/services/__test__/tokenService.spec.ts
@@ -2,6 +2,7 @@ import { TokenService } from '../tokenService';
 import jwt from 'jsonwebtoken';
 import { Types } from 'mongoose';
 import { StreamingServiceError } from '../../middleware/errorHandler';
+import { ITokenPayload } from '../../interfaces/auth';
 
 jest.mock('jsonwebtoken');
 
@@ -10,14 +11,13 @@ describe('TokenService', () => {
   const mockUserId = new Types.ObjectId();
   const mockToken = 'mock-token';
   const mockRefreshToken = 'mock-refresh-token';
-  const mockDecodedToken = { userId: mockUserId };
+  const mockDecodedToken: ITokenPayload = { userId: mockUserId };
 
   beforeEach(() => {
     process.env.JWT_SECRET = 'test-secret';
     process.env.JWT_REFRESH_SECRET = 'test-refresh-secret';
     tokenService = TokenService.getInstance();
   });
-
 
   describe('getInstance', () => {
     it('should return the same instance', () => {
@@ -70,6 +70,17 @@ describe('TokenService', () => {
       const result = tokenService.verifyToken(mockToken);
 
       expect(result).toEqual({ userId: mockUserId });
+      expect(jwt.verify).toHaveBeenCalledWith(mockToken, 'test-secret');
+    });
+
+    it('should verify a valid token with a role', () => {
+      const mockDecodedTokenWithRole: ITokenPayload = {...mockDecodedToken, userRole: "user" };
+
+      (jwt.verify as jest.Mock).mockReturnValue(mockDecodedTokenWithRole);
+      
+      const result = tokenService.verifyToken(mockToken);
+
+      expect(result).toEqual({ userId: mockUserId, role: "user" });
       expect(jwt.verify).toHaveBeenCalledWith(mockToken, 'test-secret');
     });
 

--- a/src/services/__test__/userStreamingHistoryService.spec.ts
+++ b/src/services/__test__/userStreamingHistoryService.spec.ts
@@ -7,7 +7,6 @@ import { UserStreamingHistoryService } from '../userStreamingHistoryService';
 import { IMovieResponse } from '../../interfaces/movie';
 import { ISeriesResponse } from '../../interfaces/series/series';
 import { IUserStreamingHistoryResponse, WatchHistoryEntry, EpisodeWatched, SeriesProgress } from '../../interfaces/userStreamingHistory';
-import { describe } from 'node:test';
 import { IGenreReference } from '../../interfaces/streamingTypes';
 import { generateValidObjectId } from '../../util/__tests__/generateValidObjectId';
 

--- a/src/services/streamingTypeService.ts
+++ b/src/services/streamingTypeService.ts
@@ -304,7 +304,6 @@ export class StreamingTypeService implements IStreamingTypeService {
       logger.info('Starting streaming types synchronization with genres...');
 
       const allGenres = await this.genreRepository.findAll(0, 1000);
-      console.log(allGenres.length, "allGeres");
       if (allGenres.length === 0) {
         logger.warn('No genres found. Please sync genres first.');
         return { created: 0, updated: 0 };


### PR DESCRIPTION
## ✨ Minor Improvements & Cover Automation – v1.3.1

### Summary
This PR introduces a set of minor but impactful improvements focused on testing reliability, schema optimization, and automated maintenance workflows. It refines the back-end codebase to support better maintainability, observability, and project hygiene for long-term development.

---

## ✅ Changes

### 🧪 Tests & Debugging
- Enhanced unit test coverage for:
  - `seriesController`
  - `authMiddleware`
  - `/season` routes (with mocked `CronJob` to prevent open handles)
- Added a `test:debug` script using:
  - `--detectOpenHandles`
  - `--runInBand`
  - `--logHeapUsage`
- Fixed test expectation in the `changeCover` route for consistent response formatting and status

### 🗃️ Schema & Models
- Removed redundant MongoDB indexes from:
  - `genres`
  - `streamingTypes`
  - `userStreamingHistory`

### ⚙️ Backend Logic / APIs
- Improved response from `/streamingTypes/change-cover` to include additional metadata
- Refactored controller logic to enhance readability and error handling

### 🤖 GitHub Actions
- Added a scheduled GitHub Action to:
  - Trigger `/streamingTypes/change-cover` every Sunday at 12:00 UTC
  - Wake up Render using `/health` before the sync to handle cold starts

---

## 🧠 Why
These improvements aim to stabilize automated tests, remove unnecessary index duplication in the schema, and automate the weekly update of streaming type covers — eliminating the need for manual syncs with TMDB.

---

## 🧪 How to Test

1. Run `npm run test:debug` and verify there are no open handles.
2. Manually trigger `/streamingTypes/change-cover` and confirm the new metadata in the response.
3. Navigate to GitHub → Actions → "Weekly Cover Update" and confirm the workflow executes correctly.

---

## 🔗 Related

- Part of the release for version `v1.3.1`
