### PR TITLE
feat(streaming-history): add support to mark and unmark watched seasons

### DIFF
--- a/src/constants/errorMessages.ts
+++ b/src/constants/errorMessages.ts
@@ -14,7 +14,8 @@ export const ErrorMessages = {
   HISTORY_DURATION_REQUIRED: "Streaming duration is required",
   HISTORY_DURATION_NEGATIVE: "Streaming duration must be positive",
   HISTORY_TOTAL_DURATION_NEGATIVE: "Streaming total duration must be positive",
-
+  HISTORY_SEASON_MARK_WATCHED: "Failed marking season as watched",
+  HISTORY_UPDATE_FAILED: "Failed to update history",
   // Genre errors
   GENRE_NOT_FOUND: "Genre is not found",
   GENRE_NAME_REQUIRED: "Genre name is required",

--- a/src/constants/errorMessages.ts
+++ b/src/constants/errorMessages.ts
@@ -15,6 +15,7 @@ export const ErrorMessages = {
   HISTORY_DURATION_NEGATIVE: "Streaming duration must be positive",
   HISTORY_TOTAL_DURATION_NEGATIVE: "Streaming total duration must be positive",
   HISTORY_SEASON_MARK_WATCHED: "Failed marking season as watched",
+  HISTORY_SEASON_UNMARK_WATCHED: "Failed unmarking season as watched",
   HISTORY_UPDATE_FAILED: "Failed to update history",
   // Genre errors
   GENRE_NOT_FOUND: "Genre is not found",

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -31,12 +31,13 @@ export const Messages = {
   STREAMING_TYPE_CATEGORIES_ADDED_SUCCESSFULLY: 'Categories added successfully',
   STREAMING_TYPE_CATEGORIES_REMOVED_SUCCESSFULLY: 'Categories removed successfully',
   STREAMING_TYPE_COVER_CHANGE_SUCCESSFULLY: "Covers changed successfully",
+
   // History Streaming messages
   STREAMING_HISTORY_FOUND: 'Streaming history found',
   STREAMING_ADDED_SUCCESSFULLY: 'Streaming added successfully',
   STREAMING_REMOVED_SUCCESSFULLY: 'Streaming removed successfully',
   STREAMING_NOT_FOUND: 'Streaming not found or failed to update history',
-
+  HISTORY_STREAMING_MARKED_SUCCESSFULLY: "Season marked as watched",
   // Authentication & Authorization messages
   AUTHENTICATION_SUCCESS: 'Authentication successful',
   LOGOUT_SUCCESS: 'Logout successful',

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -38,6 +38,7 @@ export const Messages = {
   STREAMING_REMOVED_SUCCESSFULLY: 'Streaming removed successfully',
   STREAMING_NOT_FOUND: 'Streaming not found or failed to update history',
   HISTORY_STREAMING_MARKED_SUCCESSFULLY: "Season marked as watched",
+  HISTORY_STREAMING_UNMARKED_SUCCESSFULLY: "Season unmarked as watched",
   // Authentication & Authorization messages
   AUTHENTICATION_SUCCESS: 'Authentication successful',
   LOGOUT_SUCCESS: 'Logout successful',

--- a/src/controllers/__tests__/userStreamingHistoryController.spec.ts
+++ b/src/controllers/__tests__/userStreamingHistoryController.spec.ts
@@ -10,6 +10,24 @@ import { MovieRepository } from '../../repositories/movieRepository';
 
 jest.mock('../../services/userStreamingHistoryService');
 
+function createMockWatchHistoryEntry(
+  overrides: Partial<WatchHistoryEntry> = {}
+): WatchHistoryEntry {
+  const defaultId = new Types.ObjectId(generateValidObjectId());
+
+  return {
+    contentId: defaultId,
+    contentType: 'series',
+    title: 'Mock Title',
+    watchedDurationInMinutes: 100,
+    completionPercentage: 80,
+    rating: 4,
+    watchedAt: new Date(),
+    seriesProgress: new Map(),
+    ...overrides
+  };
+}
+
 describe('UserStreamingHistoryController', () => {
   let controller: UserStreamingHistoryController;
   let mockService: jest.Mocked<UserStreamingHistoryService>;
@@ -53,13 +71,13 @@ describe('UserStreamingHistoryController', () => {
       completed: false
     }
 
-    mockWatchHistoryEntry = [{
-      contentId: validId,
-      contentType: 'movie',
-      title: 'Test Movie',
-      watchedDurationInMinutes: 120,
-      completionPercentage: 100,
-    }];
+    mockWatchHistoryEntry = [
+      createMockWatchHistoryEntry({
+        watchedDurationInMinutes: 0,
+        completionPercentage: 0,
+        rating: 0,
+      })
+    ];
   });
   beforeEach(() => {
     mockHistory = {
@@ -174,16 +192,12 @@ describe('UserStreamingHistoryController', () => {
         episodeId: episodeId.toString()
       };
 
-      const watchHistoryEntry: WatchHistoryEntry = {
-        contentId: contentId,
-        contentType: 'series',
-        title: 'Test Series',
+      const watchHistoryEntry = createMockWatchHistoryEntry({
+        contentId,
         watchedDurationInMinutes: 45,
         completionPercentage: 100,
         rating: 5,
-        watchedAt: new Date(),
-        seriesProgress: new Map()
-      };
+      });
 
       mockService.removeEpisodeFromHistory.mockResolvedValue(watchHistoryEntry);
 
@@ -252,16 +266,12 @@ describe('UserStreamingHistoryController', () => {
       };
       mockReq.body = { userId, contentId, episodeData };
 
-      const watchHistoryEntry: WatchHistoryEntry = {
-        contentId: contentId,
-        contentType: 'series',
-        title: 'Test Series',
+      const watchHistoryEntry = createMockWatchHistoryEntry({
+        contentId,
         watchedDurationInMinutes: episodeData.watchedDurationInMinutes,
         completionPercentage: episodeData.completionPercentage,
         rating: 5,
-        watchedAt: new Date(),
-        seriesProgress: new Map()
-      };
+      });
 
       mockService.addEpisodeToHistory.mockResolvedValue(watchHistoryEntry);
 
@@ -287,15 +297,12 @@ describe('UserStreamingHistoryController', () => {
       const seasonNumber = 1;
       mockReq.body = { userId, contentId, seasonNumber };
 
-      const watchHistoryEntry: WatchHistoryEntry = {
-        contentId: contentId,
-        contentType: 'series',
-        title: 'Test Series',
+      const watchHistoryEntry = createMockWatchHistoryEntry({
+        contentId,
         watchedDurationInMinutes: 0,
         completionPercentage: 0,
-        seriesProgress: new Map(),
-        watchedAt: new Date(),
-      };
+        rating: 0,
+      });
 
       mockService.markSeasonAsWatched.mockResolvedValue(watchHistoryEntry);
 
@@ -306,6 +313,39 @@ describe('UserStreamingHistoryController', () => {
       expect(mockRes.json).toHaveBeenCalledWith({ message: 'Season marked as watched', history: watchHistoryEntry });
     });
   });
+
+  describe('unMarkSeasonAsWatched', () => {
+    it('should unmark a season as watched', async () => {
+      const userId = validId;
+      const contentId = validId;
+      const seasonNumber = 1;
+  
+      mockReq.body = { userId, contentId, seasonNumber };
+  
+      const watchHistoryEntry = createMockWatchHistoryEntry({
+        contentId,
+        watchedDurationInMinutes: 0,
+        completionPercentage: 0,
+        rating: 0,
+      });
+  
+      mockService.unMarkSeasonAsWatched.mockResolvedValue(watchHistoryEntry);
+  
+      await controller.unMarkSeasonAsWatched(mockReq as Request, mockRes as Response, mockNext);
+  
+      expect(mockService.unMarkSeasonAsWatched).toHaveBeenCalledWith(
+        userId,
+        contentId,
+        seasonNumber
+      );
+  
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Season unmarked as watched',
+        history: watchHistoryEntry
+      });
+    });
+  });  
 
   describe('getEpisodesWatched', () => {
     it('should get episodes watched', async () => {

--- a/src/controllers/__tests__/userStreamingHistoryController.spec.ts
+++ b/src/controllers/__tests__/userStreamingHistoryController.spec.ts
@@ -280,6 +280,33 @@ describe('UserStreamingHistoryController', () => {
     });
   });
 
+  describe('markSeasonAsWatched', () => {
+    it('should mark season as watched', async () => {
+      const userId = validId;
+      const contentId = validId;
+      const seasonNumber = 1;
+      mockReq.body = { userId, contentId, seasonNumber };
+
+      const watchHistoryEntry: WatchHistoryEntry = {
+        contentId: contentId,
+        contentType: 'series',
+        title: 'Test Series',
+        watchedDurationInMinutes: 0,
+        completionPercentage: 0,
+        seriesProgress: new Map(),
+        watchedAt: new Date(),
+      };
+
+      mockService.markSeasonAsWatched.mockResolvedValue(watchHistoryEntry);
+
+      await controller.markSeasonAsWatched(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockService.markSeasonAsWatched).toHaveBeenCalledWith(userId, contentId, seasonNumber);
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith({ message: 'Season marked as watched', history: watchHistoryEntry });
+    });
+  });
+
   describe('getEpisodesWatched', () => {
     it('should get episodes watched', async () => {
       const userId = validId;

--- a/src/controllers/userStreamingHistoryController.ts
+++ b/src/controllers/userStreamingHistoryController.ts
@@ -148,6 +148,22 @@ export class UserStreamingHistoryController {
     const history = await this.service.markSeasonAsWatched(userId, contentId, seasonNumber);
     res.status(200).json({ message: 'Season marked as watched', history });
   });
+
+  unMarkSeasonAsWatched = catchAsync(async (req: Request, res: Response) => {
+    const { userId, contentId, seasonNumber } = req.body;
+
+    logger.info({
+      message: 'UnMark season as watched',
+      userId,
+      contentId,
+      seasonNumber,
+      method: req.method,
+      path: req.path,
+    });
+
+    const history = await this.service.unMarkSeasonAsWatched(userId, contentId, seasonNumber);
+    res.status(200).json({ message: 'Season unmarked as watched', history });
+  });
   
   getEpisodesWatched = catchAsync(async (req: Request, res: Response) => {
     const { userId, contentId } = req.query as { userId: string; contentId: string; };

--- a/src/controllers/userStreamingHistoryController.ts
+++ b/src/controllers/userStreamingHistoryController.ts
@@ -131,7 +131,23 @@ export class UserStreamingHistoryController {
 
     const history = await this.service.addEpisodeToHistory(userId, contentId, episodeData);
     res.status(201).json({ message: 'Episode added to history successfully', history });
-  }); 
+  });
+
+  markSeasonAsWatched = catchAsync(async (req: Request, res: Response) => {
+    const { userId, contentId, seasonNumber } = req.body;
+
+    logger.info({
+      message: 'Mark season as watched',
+      userId,
+      contentId,
+      seasonNumber,
+      method: req.method,
+      path: req.path,
+    });
+
+    const history = await this.service.markSeasonAsWatched(userId, contentId, seasonNumber);
+    res.status(200).json({ message: 'Season marked as watched', history });
+  });
   
   getEpisodesWatched = catchAsync(async (req: Request, res: Response) => {
     const { userId, contentId } = req.query as { userId: string; contentId: string; };

--- a/src/interfaces/repositories.ts
+++ b/src/interfaces/repositories.ts
@@ -42,6 +42,7 @@ export interface IUserStreamingHistoryRepository extends IBaseRepository<IUserSt
     episodeId: string | Types.ObjectId,
   ): Promise<WatchHistoryEntry | null>;
   updateEpisodeProgress(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, episodeData: EpisodeWatched): Promise<WatchHistoryEntry | null>;  
+  updateSeasonProgress(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, episodeData: EpisodeWatched[]): Promise<WatchHistoryEntry | null>;  
 }
 
 export interface IStreamingTypeRepository extends IBaseRepository<IStreamingTypeResponse, IStreamingTypeCreate, IStreamingTypeUpdate> {

--- a/src/interfaces/repositories.ts
+++ b/src/interfaces/repositories.ts
@@ -43,6 +43,7 @@ export interface IUserStreamingHistoryRepository extends IBaseRepository<IUserSt
   ): Promise<WatchHistoryEntry | null>;
   updateEpisodeProgress(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, episodeData: EpisodeWatched): Promise<WatchHistoryEntry | null>;  
   updateSeasonProgress(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, episodeData: EpisodeWatched[]): Promise<WatchHistoryEntry | null>;  
+  unMarkSeasonAsWatched(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, seasonNumber: number): Promise<WatchHistoryEntry | null>;  
 }
 
 export interface IStreamingTypeRepository extends IBaseRepository<IStreamingTypeResponse, IStreamingTypeCreate, IStreamingTypeUpdate> {

--- a/src/interfaces/services.ts
+++ b/src/interfaces/services.ts
@@ -23,6 +23,7 @@ export interface IUserStreamingHistoryService {
   getTotalWatchTime(userId: string | Types.ObjectId): Promise<number>;
   addEpisodeToHistory(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, episodeData: EpisodeWatched): Promise<WatchHistoryEntry | null>;
   markSeasonAsWatched(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, seasonNumber: number): Promise<WatchHistoryEntry | null>;
+  unMarkSeasonAsWatched(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, seasonNumber: number): Promise<WatchHistoryEntry | null>;
   getEpisodesWatched(userId: string | Types.ObjectId, contentId: string | Types.ObjectId): Promise<Map<string, EpisodeWatched> | null>;
 }
 

--- a/src/interfaces/services.ts
+++ b/src/interfaces/services.ts
@@ -22,6 +22,7 @@ export interface IUserStreamingHistoryService {
   removeEpisodeFromHistory(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, episodeId: string | Types.ObjectId): Promise<WatchHistoryEntry | null>;
   getTotalWatchTime(userId: string | Types.ObjectId): Promise<number>;
   addEpisodeToHistory(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, episodeData: EpisodeWatched): Promise<WatchHistoryEntry | null>;
+  markSeasonAsWatched(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, seasonNumber: number): Promise<WatchHistoryEntry | null>;
   getEpisodesWatched(userId: string | Types.ObjectId, contentId: string | Types.ObjectId): Promise<Map<string, EpisodeWatched> | null>;
 }
 

--- a/src/interfaces/userStreamingHistory.ts
+++ b/src/interfaces/userStreamingHistory.ts
@@ -69,4 +69,5 @@ export interface IUserStreamingHistoryModel extends Model<IUserStreamingHistoryD
   calculateNextEpisode(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, seasonNumber: number): Promise<number>;
   updateEpisodeProgress(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, episodeDate: EpisodeWatched): Promise<WatchHistoryEntry | null>;
   updateSeasonProgress(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, episodesWatches: EpisodeWatched[]): Promise<WatchHistoryEntry | null>;
+  unMarkSeasonAsWatched(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, seasonNumber: number): Promise<WatchHistoryEntry | null>;
 }

--- a/src/interfaces/userStreamingHistory.ts
+++ b/src/interfaces/userStreamingHistory.ts
@@ -68,4 +68,5 @@ export interface IUserStreamingHistoryModel extends Model<IUserStreamingHistoryD
   getWatchedEpisodesForSeries(userId: string | Types.ObjectId, contentId: string | Types.ObjectId): Promise<EpisodeWatched[]>;
   calculateNextEpisode(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, seasonNumber: number): Promise<number>;
   updateEpisodeProgress(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, episodeDate: EpisodeWatched): Promise<WatchHistoryEntry | null>;
+  updateSeasonProgress(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, episodesWatches: EpisodeWatched[]): Promise<WatchHistoryEntry | null>;
 }

--- a/src/models/userStreamingHistoryModel.ts
+++ b/src/models/userStreamingHistoryModel.ts
@@ -479,16 +479,11 @@ userStreamingHistorySchema.static("updateSeasonProgress", async function(
   
   const baseEntryPath = `watchHistory.${seriesEntryIndex}`;   
   const seriesEntryPath = `watchHistory.${seriesEntryIndex}.seriesProgress.${seriesId}`;
-
+  
   const seriesEntry = userHistory.watchHistory[seriesEntryIndex];
-  const seriesProgress = seriesEntry.seriesProgress?.get(seriesId) || {
-    totalEpisodes: 0,
-    watchedEpisodes: 0,
-    episodesWatched: new Map<string, EpisodeWatched>(),
-    completed: false
-  };
+  const seriesProgress = seriesEntry.seriesProgress!.get(seriesId);
 
-  const updatedEpisodesMap = new Map(seriesProgress.episodesWatched || []);
+  const updatedEpisodesMap = new Map(seriesProgress!.episodesWatched);
   let newWatchedCount = 0;
   let addDuration = 0;
 
@@ -507,16 +502,16 @@ userStreamingHistorySchema.static("updateSeasonProgress", async function(
   
   const updateObj: any = {};
   updateObj[`${seriesEntryPath}.episodesWatched`] = Object.fromEntries(updatedEpisodesMap);
-  updateObj[`${seriesEntryPath}.watchedEpisodes`] = (seriesProgress.watchedEpisodes || 0) + newWatchedCount;
+  updateObj[`${seriesEntryPath}.watchedEpisodes`] = (seriesProgress!.watchedEpisodes || 0) + newWatchedCount;
   updateObj[`${seriesEntryPath}.lastWatched`] = episodes[episodes.length - 1];
 
-  const currentDuration = seriesEntry.watchedDurationInMinutes || 0;
+  const currentDuration = seriesEntry.watchedDurationInMinutes;
   updateObj[`${baseEntryPath}.watchedDurationInMinutes`] = Math.max(currentDuration + addDuration, 0);
 
   const totalWatchPath = 'totalWatchTimeInMinutes';
   const currentTotalWatch = userHistory.totalWatchTimeInMinutes || 0;
   updateObj[totalWatchPath] = Math.max(currentTotalWatch + addDuration, 0);
-
+  
   const updatedHistory = await this.findOneAndUpdate(
     { userId },
     { $set: updateObj },

--- a/src/repositories/__tests__/userStreamingHistoryRepository.unit.spec.ts
+++ b/src/repositories/__tests__/userStreamingHistoryRepository.unit.spec.ts
@@ -324,4 +324,71 @@ describe('UserStreamingHistoryRepository', () => {
       expect(result).toBeNull();
     });
   });
+
+  describe('updateSeasonProgress', () => {
+    it('should update season progress', async () => {
+      const episodesWatched: EpisodeWatched[] = [mockEpisodeWatched];
+  
+      jest.spyOn(UserStreamingHistory, 'updateSeasonProgress').mockResolvedValue(mockWatchHistoryEntry);
+  
+      const result = await repository.updateSeasonProgress(
+        mockHistory.userId.toString(),
+        mockWatchHistoryEntry.contentId.toString(),
+        episodesWatched
+      );
+  
+      expect(UserStreamingHistory.updateSeasonProgress).toHaveBeenCalledWith(
+        mockHistory.userId.toString(),
+        mockWatchHistoryEntry.contentId.toString(),
+        episodesWatched
+      );
+      expect(result).toEqual(mockWatchHistoryEntry);
+    });
+  
+    it('should return null if season progress not updated', async () => {
+      const episodesWatched: EpisodeWatched[] = [mockEpisodeWatched];
+  
+      jest.spyOn(UserStreamingHistory, 'updateSeasonProgress').mockResolvedValue(null);
+  
+      const result = await repository.updateSeasonProgress(
+        mockHistory.userId.toString(),
+        mockWatchHistoryEntry.contentId.toString(),
+        episodesWatched
+      );
+  
+      expect(result).toBeNull();
+    });
+  });
+  
+  describe('unMarkSeasonAsWatched', () => {
+    it('should unmark season as watched', async () => {
+      jest.spyOn(UserStreamingHistory, 'unMarkSeasonAsWatched').mockResolvedValue(mockWatchHistoryEntry);
+  
+      const result = await repository.unMarkSeasonAsWatched(
+        mockHistory.userId.toString(),
+        mockWatchHistoryEntry.contentId.toString(),
+        1
+      );
+  
+      expect(UserStreamingHistory.unMarkSeasonAsWatched).toHaveBeenCalledWith(
+        mockHistory.userId.toString(),
+        mockWatchHistoryEntry.contentId.toString(),
+        1
+      );
+      expect(result).toEqual(mockWatchHistoryEntry);
+    });
+  
+    it('should return null if unmark fails', async () => {
+      jest.spyOn(UserStreamingHistory, 'unMarkSeasonAsWatched').mockResolvedValue(null);
+  
+      const result = await repository.unMarkSeasonAsWatched(
+        mockHistory.userId.toString(),
+        mockWatchHistoryEntry.contentId.toString(),
+        1
+      );
+  
+      expect(result).toBeNull();
+    });
+  });
+  
 }); 

--- a/src/repositories/userStreamingHistoryRepository.ts
+++ b/src/repositories/userStreamingHistoryRepository.ts
@@ -44,6 +44,10 @@ export class UserStreamingHistoryRepository implements IUserStreamingHistoryRepo
     return UserStreamingHistory.updateSeasonProgress(userId,  seasonId, episodesWatches);
   }
 
+  async unMarkSeasonAsWatched(userId: string | Types.ObjectId, seasonId: string | Types.ObjectId, seasonNumber: number): Promise<WatchHistoryEntry | null> {
+    return UserStreamingHistory.unMarkSeasonAsWatched(userId,  seasonId, seasonNumber);
+  }
+
   async delete(id: string | Types.ObjectId): Promise<IUserStreamingHistoryResponse | null> {
     return UserStreamingHistory.findByIdAndDelete(id);
   }

--- a/src/repositories/userStreamingHistoryRepository.ts
+++ b/src/repositories/userStreamingHistoryRepository.ts
@@ -40,6 +40,10 @@ export class UserStreamingHistoryRepository implements IUserStreamingHistoryRepo
     return UserStreamingHistory.updateEpisodeProgress(userId, contentId, episodeData);
   }
 
+  async updateSeasonProgress(userId: string | Types.ObjectId, seasonId: string | Types.ObjectId, episodesWatches: EpisodeWatched[]): Promise<WatchHistoryEntry | null> {
+    return UserStreamingHistory.updateSeasonProgress(userId,  seasonId, episodesWatches);
+  }
+
   async delete(id: string | Types.ObjectId): Promise<IUserStreamingHistoryResponse | null> {
     return UserStreamingHistory.findByIdAndDelete(id);
   }

--- a/src/routes/__test__/userStreamingHistoryRoutes.spec.ts
+++ b/src/routes/__test__/userStreamingHistoryRoutes.spec.ts
@@ -14,7 +14,8 @@ const mockImplementations = {
   addEpisodeToHistory: jest.fn(),
   removeEpisodeFromHistory: jest.fn(),
   getEpisodesWatched: jest.fn(),
-  markSeasonAsWatched: jest.fn()
+  markSeasonAsWatched: jest.fn(),
+  unMarkSeasonAsWatched: jest.fn()
 };
 
 jest.mock('../../controllers/userStreamingHistoryController', () => ({

--- a/src/routes/__test__/userStreamingHistoryRoutes.spec.ts
+++ b/src/routes/__test__/userStreamingHistoryRoutes.spec.ts
@@ -13,7 +13,8 @@ const mockImplementations = {
   getByUserIdAndStreamingId: jest.fn(),
   addEpisodeToHistory: jest.fn(),
   removeEpisodeFromHistory: jest.fn(),
-  getEpisodesWatched: jest.fn()
+  getEpisodesWatched: jest.fn(),
+  markSeasonAsWatched: jest.fn()
 };
 
 jest.mock('../../controllers/userStreamingHistoryController', () => ({
@@ -277,6 +278,27 @@ describe('User Streaming History Routes', () => {
 
       expect(response.body).toHaveProperty('message', 'Episode added to history successfully');
       expect(response.body).toHaveProperty('episode');
+    });
+  });
+
+  describe('POST /mark-season-watched', () => {
+    it('should mark season as watched', async () => {
+      const payload = {
+        userId: mockUserId.toString(),
+        contentId: mockContentId.toString(),
+        seasonNumber: 1,
+      };
+
+      mockImplementations.markSeasonAsWatched = jest.fn((req: Request, res: Response) => {
+        res.status(HttpStatus.OK).json({ message: 'Season marked as watched' });
+      });
+
+      const response = await request(app)
+        .post('/streaming-history/mark-season-watched')
+        .send(payload)
+        .expect(HttpStatus.OK);
+
+      expect(response.body).toEqual({ message: 'Season marked as watched' });
     });
   });
 

--- a/src/routes/__test__/userStreamingHistoryRoutes.spec.ts
+++ b/src/routes/__test__/userStreamingHistoryRoutes.spec.ts
@@ -289,7 +289,7 @@ describe('User Streaming History Routes', () => {
         seasonNumber: 1,
       };
 
-      mockImplementations.markSeasonAsWatched = jest.fn((req: Request, res: Response) => {
+      mockImplementations.markSeasonAsWatched.mockImplementation((req: Request, res: Response) => {
         res.status(HttpStatus.OK).json({ message: 'Season marked as watched' });
       });
 

--- a/src/routes/userStreamingHistoryRoutes.ts
+++ b/src/routes/userStreamingHistoryRoutes.ts
@@ -25,6 +25,13 @@ const controller = new UserStreamingHistoryController(userStreamingHistoryServic
 
 /**
  * @swagger
+ * tags:
+ *   name: Streaming History
+ *   description: User streaming history management
+ */
+
+/**
+ * @swagger
  * /user-streaming-history/get-episodes-watched:
  *   get:
  *     summary: Get episodes watched by user
@@ -48,13 +55,6 @@ router.get('/get-episodes-watched',
   validateObjectId('query', 'userId'),
   validateObjectId('query', 'contentId'),
   controller.getEpisodesWatched);
-
-/**
- * @swagger
- * tags:
- *   name: Streaming History
- *   description: User streaming history management
- */
 
 /**
  * @swagger
@@ -296,7 +296,7 @@ router.post(
  *               - seasonNumber
  *     responses:
  *       200:
- *         description: New history
+ *         description: A history object
  *       400:
  *         description: Invalid request data
  *       500:

--- a/src/routes/userStreamingHistoryRoutes.ts
+++ b/src/routes/userStreamingHistoryRoutes.ts
@@ -280,6 +280,37 @@ router.post(
 
 /**
  * @swagger
+ * /user-streaming-history/unmark-season-watched:
+ *   post:
+ *     summary: UnMark all episodes from a season as watched
+ *     tags: [Streaming History]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - userId
+ *               - contentId
+ *               - seasonNumber
+ *     responses:
+ *       200:
+ *         description: New history
+ *       400:
+ *         description: Invalid request data
+ *       500:
+ *         description: Server error
+ */
+
+router.delete(
+  '/unmark-season-watched',
+  validate(userStreamingHistoryMarkSeasonSchema),
+  controller.unMarkSeasonAsWatched,
+);
+
+/**
+ * @swagger
  * /user-streaming-history/total-watch-time/{userId}:
  *   get:
  *     summary: Get user's total watch time

--- a/src/routes/userStreamingHistoryRoutes.ts
+++ b/src/routes/userStreamingHistoryRoutes.ts
@@ -25,7 +25,7 @@ const controller = new UserStreamingHistoryController(userStreamingHistoryServic
 
 /**
  * @swagger
- * /streaming-history/get-episodes-watched:
+ * /user-streaming-history/get-episodes-watched:
  *   get:
  *     summary: Get episodes watched by user
  *     tags: [Streaming History]
@@ -58,7 +58,7 @@ router.get('/get-episodes-watched',
 
 /**
  * @swagger
- * /streaming-history/{userId}:
+ * /user-streaming-history/{userId}:
  *   get:
  *     summary: Get user's streaming history
  *     tags: [Streaming History]
@@ -84,7 +84,7 @@ router.get('/:userId',
 
 /**
  * @swagger
- * /streaming-history:
+ * /user-streaming-history:
  *   post:
  *     summary: Add streaming entry to user's history
  *     tags: [Streaming History]
@@ -124,7 +124,7 @@ router.post(
 
 /**
  * @swagger
- * /streaming-history/remove-entry:
+ * /user-streaming-history/remove-entry:
  *   delete:
  *     summary: Remove streaming entry from user's history
  *     tags: [Streaming History]
@@ -155,7 +155,7 @@ router.delete(
 
 /**
  * @swagger
- * /streaming-history/remove-episode:
+ * /user-streaming-history/remove-episode:
  *   delete:
  *     summary: Remove streaming episode from user's history
  *     tags: [Streaming History]
@@ -188,7 +188,7 @@ router.delete(
 
 /**
  * @swagger
- * /streaming-history:
+ * /user-streaming-history:
  *   get:
  *     summary: Get user's streaming view by id
  *     tags: [Streaming History]
@@ -219,7 +219,7 @@ router.get(
 
 /**
  * @swagger
- * /streaming-history/add-episode:
+ * /user-streaming-history/add-episode:
  *   post:
  *     summary: Add episode to user's history
  *     tags: [Streaming History]
@@ -249,7 +249,7 @@ router.post(
 
 /**
  * @swagger
- * /streaming-history/mark-season-watched:
+ * /user-streaming-history/mark-season-watched:
  *   post:
  *     summary: Mark all episodes from a season as watched
  *     tags: [Streaming History]
@@ -280,7 +280,7 @@ router.post(
 
 /**
  * @swagger
- * /streaming-history/total-watch-time/{userId}:
+ * /user-streaming-history/total-watch-time/{userId}:
  *   get:
  *     summary: Get user's total watch time
  *     tags: [Streaming History]

--- a/src/routes/userStreamingHistoryRoutes.ts
+++ b/src/routes/userStreamingHistoryRoutes.ts
@@ -8,11 +8,12 @@ import { validateObjectId } from '../middleware/objectIdValidationMiddleware';
 import { validate } from '../middleware/validationMiddleware';
 import { paginationSchema } from '../validators';
 import { 
-  userStreamingHistoryAddEntrySchema, 
+  userStreamingHistoryAddEntrySchema,
   userStreamingHistoryRemoveEntrySchema,
   userStreamingHistoryGetByUserIdAndStreamingIdSchema,
   userStreamingHistoryAddEpisodeSchema,
-  userStreamingHistoryRemoveEpisodeSchema, 
+  userStreamingHistoryRemoveEpisodeSchema,
+  userStreamingHistoryMarkSeasonSchema,
 } from '../validators/userStreamingHistorySchema';
 
 const router: Router = Router();
@@ -244,6 +245,37 @@ router.post(
   '/add-episode',
   validate(userStreamingHistoryAddEpisodeSchema),
   controller.addEpisodeToHistory,
+);
+
+/**
+ * @swagger
+ * /streaming-history/mark-season-watched:
+ *   post:
+ *     summary: Mark all episodes from a season as watched
+ *     tags: [Streaming History]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - userId
+ *               - contentId
+ *               - seasonNumber
+ *     responses:
+ *       200:
+ *         description: Season marked as watched
+ *       400:
+ *         description: Invalid request data
+ *       500:
+ *         description: Server error
+ */
+
+router.post(
+  '/mark-season-watched',
+  validate(userStreamingHistoryMarkSeasonSchema),
+  controller.markSeasonAsWatched,
 );
 
 /**

--- a/src/services/__test__/userStreamingHistoryService.spec.ts
+++ b/src/services/__test__/userStreamingHistoryService.spec.ts
@@ -305,15 +305,15 @@ describe('UserStreamingHistoryService', () => {
         episodeNumber: 1,
         durationInMinutes: 45,
       }];
-      const season = { episodes } as any;
-      jest.spyOn(mockUserStreamingHistoryRepository, 'updateEpisodeProgress').mockResolvedValue(mockWatchHistoryEntry);
+      const season = { episodes, _id: mockContentId } as any;
+      jest.spyOn(mockUserStreamingHistoryRepository, 'updateSeasonProgress').mockResolvedValue(mockWatchHistoryEntry);
       const seasonRepo = (userStreamingHistoryService as any).seasonRepository;
       jest.spyOn(seasonRepo, 'findEpisodesBySeasonNumber').mockResolvedValue(season);
 
       const result = await userStreamingHistoryService.markSeasonAsWatched(mockUserId, mockContentId, 1);
 
       expect(seasonRepo.findEpisodesBySeasonNumber).toHaveBeenCalledWith(mockContentId, 1);
-      expect(mockUserStreamingHistoryRepository.updateEpisodeProgress).toHaveBeenCalled();
+      expect(mockUserStreamingHistoryRepository.updateSeasonProgress).toHaveBeenCalled();
       expect(result).toEqual(mockWatchHistoryEntry);
     });
   });

--- a/src/services/__test__/userStreamingHistoryService.spec.ts
+++ b/src/services/__test__/userStreamingHistoryService.spec.ts
@@ -298,6 +298,26 @@ describe('UserStreamingHistoryService', () => {
     });
   });
 
+  describe('markSeasonAsWatched', () => {
+    it('should mark season as watched', async () => {
+      const episodes = [{
+        _id: mockEpisodeId.toString(),
+        episodeNumber: 1,
+        durationInMinutes: 45,
+      }];
+      const season = { episodes } as any;
+      jest.spyOn(mockUserStreamingHistoryRepository, 'updateEpisodeProgress').mockResolvedValue(mockWatchHistoryEntry);
+      const seasonRepo = (userStreamingHistoryService as any).seasonRepository;
+      jest.spyOn(seasonRepo, 'findEpisodesBySeasonNumber').mockResolvedValue(season);
+
+      const result = await userStreamingHistoryService.markSeasonAsWatched(mockUserId, mockContentId, 1);
+
+      expect(seasonRepo.findEpisodesBySeasonNumber).toHaveBeenCalledWith(mockContentId, 1);
+      expect(mockUserStreamingHistoryRepository.updateEpisodeProgress).toHaveBeenCalled();
+      expect(result).toEqual(mockWatchHistoryEntry);
+    });
+  });
+
   describe('getEpisodesWatched', () => {
     it('should return episodes watched for a series', async () => {
       const historyWithEpisodes = {

--- a/src/services/userStreamingHistoryService.ts
+++ b/src/services/userStreamingHistoryService.ts
@@ -147,6 +147,25 @@ export class UserStreamingHistoryService implements IUserStreamingHistoryService
     return updatedHistory;
   }
 
+  async unMarkSeasonAsWatched(userId: string | Types.ObjectId, contentId: string | Types.ObjectId, seasonNumber: number): Promise<WatchHistoryEntry | null> {
+    const updatedHistory = await this.repository.unMarkSeasonAsWatched(userId, contentId, seasonNumber);
+    if (!updatedHistory) {
+      logger.error({
+        message: ErrorMessages.HISTORY_SEASON_UNMARK_WATCHED,
+        error: ErrorMessages.HISTORY_UPDATE_FAILED,
+        userId,
+        contentId,
+      });
+      throw new StreamingServiceError(ErrorMessages.HISTORY_UPDATE_FAILED, 404);
+    }
+    logger.info({
+      message: Messages.HISTORY_STREAMING_UNMARKED_SUCCESSFULLY,
+      userId,
+      contentId,
+    });
+    return updatedHistory
+  }
+
   async getEpisodesWatched(userId: string | Types.ObjectId, contentId: string | Types.ObjectId): Promise<Map<string, EpisodeWatched> | null> {
     const history = await this.getUserHistory(userId);
     const seriesProgress = history.watchHistory.find((entry) => entry.contentId.toString() === contentId.toString())?.seriesProgress?.get(contentId.toString());

--- a/src/validators/__tests__/userStreamingHistorySchema.spec.ts
+++ b/src/validators/__tests__/userStreamingHistorySchema.spec.ts
@@ -4,9 +4,8 @@ import {
   userStreamingHistoryUpdateSchema,
   userStreamingHistoryAddEntrySchema,
   userContentIdentifierSchema,
-  userStreamingHistoryRemoveEntrySchema,
   userStreamingHistoryRemoveEpisodeSchema,
-  userStreamingHistoryGetByUserIdAndStreamingIdSchema,
+  userStreamingHistoryMarkSeasonSchema,
   userStreamingHistoryAddEpisodeSchema
 } from '../userStreamingHistorySchema';
 
@@ -539,3 +538,84 @@ describe('userStreamingHistoryAddEpisodeSchema', () => {
     }
   });
 }); 
+
+describe('userStreamingHistoryMarkSeasonSchema', () => {
+  const validId = new Types.ObjectId();
+
+  it('should validate a valid input', () => {
+    const validInput = {
+      userId: validId,
+      contentId: validId,
+      seasonNumber: 1
+    };
+
+    const result = userStreamingHistoryMarkSeasonSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  it('should fail when userId is missing', () => {
+    const input = {
+      contentId: validId,
+      seasonNumber: 1
+    };
+
+    const result = userStreamingHistoryMarkSeasonSchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail when contentId is missing', () => {
+    const input = {
+      userId: validId,
+      seasonNumber: 1
+    };
+
+    const result = userStreamingHistoryMarkSeasonSchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail when seasonNumber is missing', () => {
+    const input = {
+      userId: validId,
+      contentId: validId
+    };
+
+    const result = userStreamingHistoryMarkSeasonSchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail when seasonNumber is less than 1', () => {
+    const input = {
+      userId: validId,
+      contentId: validId,
+      seasonNumber: 0
+    };
+
+    const result = userStreamingHistoryMarkSeasonSchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail when seasonNumber is not a number', () => {
+    const input = {
+      userId: validId,
+      contentId: validId,
+      seasonNumber: '1'
+    };
+
+    const result = userStreamingHistoryMarkSeasonSchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail when userId and contentId are invalid strings', () => {
+    const input = {
+      userId: 'invalid',
+      contentId: 'invalid',
+      seasonNumber: 2
+    };
+
+    const result = userStreamingHistoryMarkSeasonSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.errors.some(e => e.message.includes('Invalid ID'))).toBe(true);
+    }
+  });
+});

--- a/src/validators/userStreamingHistorySchema.ts
+++ b/src/validators/userStreamingHistorySchema.ts
@@ -75,3 +75,9 @@ export const userStreamingHistoryAddEpisodeSchema = z.object({
   contentId: objectIdSchema,
   episodeData: episodeWatchedSchema,
 });
+
+export const userStreamingHistoryMarkSeasonSchema = userContentIdentifierSchema.extend({
+  seasonNumber: z.number().min(1),
+});
+
+export type UserStreamingHistoryMarkSeasonPayload = z.infer<typeof userStreamingHistoryMarkSeasonSchema>;


### PR DESCRIPTION
## ✨ Summary

Implement full support for tracking watched seasons in the user's streaming history. This includes marking and unmarking entire seasons as watched, updating episode progress accordingly, and ensuring the total watch time is accurately reflected. Extensive unit and integration tests were added to ensure correctness and full coverage.

---

## ✅ Changes

### ➕ Features
- Implemented `markSeasonAsWatched` and `unMarkSeasonAsWatched` in:
  - Controller
  - Service
  - Repository
  - Mongoose static methods
- New schema `userStreamingHistoryMarkSeasonSchema` to validate payload
- Added new routes:
  - `POST /user-streaming-history/mark-season-watched`
  - `DELETE /user-streaming-history/unmark-season-watched`

### 🧪 Tests & Debugging
- Test coverage added for all layers

## 🧠 Why

To enable a better user experience by allowing bulk updates to watched content (season level), while maintaining accurate statistics and watch progress in a consistent and testable way.

---

## 🧪 How to Test

1. Run all test suites with coverage:
   ```bash
   pnpm test:coverage

2. Manual test via Swagger or Insomnia:
  - Mark and unmark a full season
  - Verify updates in episode list and total time
---
